### PR TITLE
Add promotional enrollment banner with countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,14 @@
       </div>
     </section>
 
+    <section class="promo-banner">
+      <div class="container">
+        <p class="promo-text">Limited Seats – Enroll Now</p>
+        <p class="promo-subtext">New modules <span class="coming-soon">Coming Soon</span></p>
+        <p class="countdown-wrapper">Enrollment closes in <span id="countdown"></span></p>
+      </div>
+    </section>
+
     <section id="about" class="section about" data-aos="fade-up">
       <div class="container">
         <h2 class="section-title">Who We Are</h2>

--- a/script.js
+++ b/script.js
@@ -9,3 +9,34 @@ navToggle.addEventListener("click", () => {
 });
 
 document.getElementById("year").textContent = new Date().getFullYear();
+
+function initializeCountdown(daysFromNow) {
+  const countdownEl = document.getElementById("countdown");
+  if (!countdownEl) return;
+
+  const target = new Date();
+  target.setDate(target.getDate() + daysFromNow);
+
+  function updateCountdown() {
+    const now = new Date();
+    const diff = target - now;
+
+    if (diff <= 0) {
+      countdownEl.textContent = "0d 0h 0m 0s";
+      clearInterval(timer);
+      return;
+    }
+
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+    const minutes = Math.floor((diff / (1000 * 60)) % 60);
+    const seconds = Math.floor((diff / 1000) % 60);
+
+    countdownEl.textContent = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+  }
+
+  updateCountdown();
+  const timer = setInterval(updateCountdown, 1000);
+}
+
+initializeCountdown(7);

--- a/style.css
+++ b/style.css
@@ -157,6 +157,39 @@ img {
   color: var(--accent);
 }
 
+.promo-banner {
+  background: var(--accent);
+  color: var(--light);
+  text-align: center;
+  padding: 1rem 0.5rem;
+  animation: bannerPulse 2s infinite;
+}
+
+.promo-banner .coming-soon {
+  font-weight: 700;
+}
+
+.countdown-wrapper {
+  margin-top: 0.5rem;
+  font-weight: 600;
+}
+
+#countdown {
+  font-weight: 700;
+}
+
+@keyframes bannerPulse {
+  0% {
+    background-color: var(--accent);
+  }
+  50% {
+    background-color: var(--accent2);
+  }
+  100% {
+    background-color: var(--accent);
+  }
+}
+
 .cta {
   background: linear-gradient(135deg, var(--accent), var(--accent2));
   color: var(--light);


### PR DESCRIPTION
## Summary
- add promo banner highlighting limited seats and upcoming modules
- style banner with pulsating animation for visibility
- include simple countdown timer to create urgency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d16dc68832b81fb6ec48dca1301