### PR TITLE
fix: use absolute URLs for social preview images

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Jobaance - Learn Finance. Gain Skills. Get Job-Ready.</title>
+    <meta
+      property="og:image"
+      content="https://jobaance.com/preview.png"
+    />
+    <meta
+      name="twitter:image"
+      content="https://jobaance.com/preview.png"
+    />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
       rel="stylesheet"


### PR DESCRIPTION
## Summary
- ensure social preview images use absolute URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c472f2a8d0832b96cb785b172142df