### PR TITLE
Add Open Graph type and Twitter URL meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,16 @@
       content="https://jobaance.com/preview.png"
     />
     <meta
+      property="og:type"
+      content="website"
+    />
+    <meta
       name="twitter:image"
       content="https://jobaance.com/preview.png"
+    />
+    <meta
+      name="twitter:url"
+      content="https://jobaance.com/"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"


### PR DESCRIPTION
## Summary
- declare site type for Open Graph with `<meta property="og:type" content="website">`
- expose canonical URL in Twitter card metadata

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c473fcda98832b88821dcd023f3c37