### PR TITLE
docs: document manual deployment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,23 @@
 
 A colorful static landing page for **Jobaance** – a finance education and career training platform.
 
+## Manual Deployment (example: jobaance.myatscv.com)
 
-## Deployment
-
-1. Create an S3 bucket named after your domain (e.g., `example.com`).
-2. Enable static website hosting and apply a public-read bucket policy.
-3. Upload site files using the AWS console or:
+1. Create an S3 bucket named `jobaance.myatscv.com` and enable static website hosting with public read access.
+   Upload the site files from this repository, for example:
 
    ```bash
-   aws s3 sync . s3://example.com
+   aws s3 sync . s3://jobaance.myatscv.com
    ```
 
-4. In Route 53, create an alias `A` record pointing to the bucket website endpoint.
+2. In AWS Certificate Manager (us-east-1), request a public certificate for `jobaance.myatscv.com`.
+
+3. Create a CloudFront distribution:
+   - Origin: the S3 website endpoint for `jobaance.myatscv.com`.
+   - Attach the ACM certificate.
+   - Set the default root object to `index.html`.
+
+4. In Route 53, add an alias `A` record for `jobaance.myatscv.com` pointing to the CloudFront distribution.
 
 ### Troubleshooting
 
@@ -25,10 +30,7 @@ A colorful static landing page for **Jobaance** – a finance education and care
 ```
 ├── index.html       # Landing page markup
 ├── style.css        # Styling
-├── script.js        # Small JS for nav + animations
-├── infra
-│   └── cloudformation.yaml  # S3/Route53 infrastructure
-└── deploy.sh        # Helper script to deploy via AWS CLI
+└── script.js        # Small JS for nav + animations
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- outline manual S3/ACM/CloudFront/Route53 setup using jobaance.myatscv.com
- focus README on manual workflow and drop CloudFormation/deploy script references

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c47564e954832bbf8c959f8bcfa68f