### PR TITLE
chore: update social preview image URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Jobaance - Learn Finance. Gain Skills. Get Job-Ready.</title>
     <meta
       property="og:image"
-      content="https://jobaance.com/preview.png"
+      content="https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&w=1200&h=630&q=80"
     />
     <meta
       property="og:type"
@@ -14,7 +14,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://jobaance.com/preview.png"
+      content="https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&w=1200&h=630&q=80"
     />
     <meta
       name="twitter:url"


### PR DESCRIPTION
## Summary
- use 1200x630 Unsplash image for Open Graph & Twitter preview metadata
- remove leftover reference to local preview asset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c47e9bb3f0832b9c41ecdc2169e255