### PR TITLE
Point social preview tags to hosted image

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Jobaance - Learn Finance. Gain Skills. Get Job-Ready.</title>
     <meta
       property="og:image"
-      content="https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&w=1200&h=630&q=80"
+      content="https://cdn.pixabay.com/photo/2015/03/26/09/41/students-690068_1280.jpg"
     />
     <meta
       property="og:type"
@@ -14,7 +14,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&w=1200&h=630&q=80"
+      content="https://cdn.pixabay.com/photo/2015/03/26/09/41/students-690068_1280.jpg"
     />
     <meta
       name="twitter:url"


### PR DESCRIPTION
## Summary
- use a CDN-hosted image for Open Graph and Twitter previews

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -L -o /tmp/pixabay.jpg "http://cdn.pixabay.com/photo/2015/03/26/09/41/students-690068_1280.jpg"` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4da0ac558832bb35ae384a41fb74f