### PR TITLE
Limit hero image dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
               ></i>
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-6 image">
             <picture>
               <source
                 srcset="https://images.unsplash.com/photo-1556155092-8707de31f9c4?auto=format&fit=crop&w=1980&q=80"

--- a/style.css
+++ b/style.css
@@ -78,3 +78,15 @@ body {
 .faq-item.open .faq-question i {
   transform: rotate(180deg);
 }
+
+.hero .image img {
+  max-width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+}
+
+@media (max-width: 768px) {
+  .hero .image img {
+    max-height: 300px;
+  }
+}


### PR DESCRIPTION
## Summary
- cap hero image width/height and ensure mobile max-height
- mark hero layout column with `.image` for targeted styles

## Testing
- `python -m playwright install chromium` (fails: Domain forbidden)
- `python selenium script` (fails: unable to obtain driver for chrome)


------
https://chatgpt.com/codex/tasks/task_e_68c4e16ff80c832bb5e9cc67d35c9c9c