### PR TITLE
Add LinkedIn profile link for founder

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,26 @@
               offering practical case studies, real tools, resume guidance, and
               interview prep.
             </p>
+            <div class="mt-3">
+              <div
+                class="badge-base LI-profile-badge"
+                data-locale="en_US"
+                data-size="medium"
+                data-theme="light"
+                data-type="VERTICAL"
+                data-vanity="prashant-kumar-9970bbb6"
+                data-version="v1"
+              >
+                <a
+                  class="badge-base__link LI-simple-link"
+                  href="https://www.linkedin.com/in/prashant-kumar-9970bbb6/"
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="Connect with Founder Prashant Kumar on LinkedIn"
+                  >Connect with Founder Prashant Kumar on LinkedIn</a
+                >
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -492,5 +512,10 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
     <script src="script.js"></script>
+    <script
+      src="https://platform.linkedin.com/badges/js/profile.js"
+      async
+      defer
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Embed Prashant Kumar's LinkedIn profile in the Who We Are section
- Load LinkedIn badge script from LinkedIn's CDN

## Testing
- `npx --yes htmlhint index.html`
- `curl -I https://platform.linkedin.com/badges/js/profile.js` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e8c7ed9c832bba6e7cd437cec61f