### PR TITLE
Refactor site to rely on Bootswatch CDN and trim styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,11 +32,7 @@
       referrerpolicy="no-referrer"
     />
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
-    <!-- Bootstrap core and Lux theme -->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <!-- Bootswatch Lux theme -->
     <link
       href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/lux/bootstrap.min.css"
       rel="stylesheet"

--- a/style.css
+++ b/style.css
@@ -13,22 +13,12 @@ body {
   color: #fff;
 }
 
-.promo-banner {
-  background: linear-gradient(135deg, #ff512f, #dd2476);
-  background-size: 200% 200%;
-  color: #fff;
-  animation: bannerPulse 3s ease infinite;
-}
-
+.promo-banner,
 .cta {
   background: linear-gradient(135deg, #ff512f, #dd2476);
   color: #fff;
 }
 
-@keyframes bannerPulse {
-  0% {background-position:0% 50%;}
-  100% {background-position:100% 50%;}
-}
 .hero .image img {
   max-width: 100%;
   max-height: 400px;


### PR DESCRIPTION
## Summary
- load Lux Bootswatch theme instead of local stylesheet
- streamline custom CSS to brand colors and image sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ea068ef0832bbacb2767d15c97b2