### PR TITLE
Add founder portrait to message section

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,10 @@
     <section id="founders" class="py-5" data-aos="fade-up">
       <div class="container">
         <h2 class="section-title text-center">Founders’ Message</h2>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center align-items-center">
+          <div class="col-md-4 text-center mb-4 mb-md-0">
+            <img src="https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg" alt="Prashant Kumar" class="img-fluid rounded-circle" />
+          </div>
           <div class="col-lg-8">
             <h3>Prashant Kumar – Co-Founder & Lead Trainer</h3>
             <p>


### PR DESCRIPTION
## Summary
- Show Prashant Kumar's portrait in the Founders’ Message section with a responsive Bootstrap column and circular styling.

## Testing
- ⚠️ `npm test` (missing package.json)
- ⚠️ `curl -I https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg` (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c4edc0939c832badfd3c7720bf1b61