### PR TITLE
Add accessible email contact link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,7 +518,14 @@
             class="text-white"
             aria-label="Message Jobaance on WhatsApp"
             >WhatsApp</a
-          >
+          >.
+          Email us at
+          <a
+            href="mailto:prashantnagendra@gmail.com"
+            class="text-white"
+            aria-label="Email Jobaance at prashantnagendra@gmail.com"
+            >prashantnagendra@gmail.com</a
+          >.
         </p>
         <p>&copy; <span id="year"></span> Jobaance. All rights reserved.</p>
       </div>


### PR DESCRIPTION
## Summary
- append mailto link in the footer with accessible "Email us at" text and aria label
- ensure high-contrast styling for the email link using `text-white`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ee87cc48832b9b8f3dfd82dae92f