### PR TITLE
Add founder image and responsive styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,7 @@
           </div>
           <div class="col-lg-8">
             <h3>Prashant Kumar – Co-Founder & Lead Trainer</h3>
+            <img src="https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg" alt="Prashant Kumar" class="founder-img" />
             <p>
               Over the past 8+ years, I’ve worked with some of the world’s
               largest financial institutions, including J.P. Morgan, BNY

--- a/style.css
+++ b/style.css
@@ -36,3 +36,10 @@ body {
     max-height: 250px;
   }
 }
+
+.founder-img {
+  max-width: 200px;
+  width: 100%;
+  height: auto;
+  border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- Embed Prashant Kumar portrait beneath his founder heading in the Founders’ Message section.
- Add responsive `.founder-img` CSS with max width and circular framing.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f26f4214832bb11fb2f387790d05