### PR TITLE
Add Instagram footer link and embed script

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,6 +529,17 @@
             >prashantnagendra@gmail.com</a
           >.
         </p>
+        <p>
+          <a
+            href="https://www.instagram.com/jobaance"
+            target="_blank"
+            rel="noopener"
+            aria-label="Jobaance on Instagram"
+            class="text-white"
+          >
+            <i class="fab fa-instagram" aria-hidden="true"></i>
+          </a>
+        </p>
         <p>&copy; <span id="year"></span> Jobaance. All rights reserved.</p>
       </div>
     </footer>
@@ -541,5 +552,6 @@
       async
       defer
     ></script>
+    <script async src="https://www.instagram.com/embed.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add Instagram icon link to footer with accessible contrast.
- Include optional Instagram embed script for richer integration.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f60d20a4832ba1e3406f44c88eff