### PR TITLE
Adopt Bootswatch Lux via CDN and streamline layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,11 @@
       referrerpolicy="no-referrer"
     />
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
+    <!-- Bootstrap core -->
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
     <!-- Bootswatch Lux theme -->
     <link
       href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/lux/bootstrap.min.css"
@@ -93,7 +98,7 @@
               ></i>
             </div>
           </div>
-          <div class="col-md-6 image">
+          <div class="col-md-6">
             <picture>
               <source
                 srcset="https://images.unsplash.com/photo-1556155092-8707de31f9c4?auto=format&fit=crop&w=1980&q=80"
@@ -102,6 +107,7 @@
               <img
                 src="https://images.unsplash.com/photo-1556155092-8707de31f9c4?auto=format&fit=crop&w=987&q=80"
                 alt="Finance training"
+                class="img-fluid"
               />
             </picture>
           </div>
@@ -109,7 +115,7 @@
       </div>
     </section>
 
-    <section class="promo-banner text-center">
+    <section class="promo-banner text-center py-4">
       <div class="container">
         <p class="promo-text">Few Seats Left</p>
         <p class="promo-subtext">Secure your spot before it's gone!</p>
@@ -287,7 +293,7 @@
           </div>
           <div class="col-lg-8">
             <h3>Prashant Kumar – Co-Founder & Lead Trainer</h3>
-            <img src="https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg" alt="Prashant Kumar" class="founder-img" />
+            <img src="https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg" alt="Prashant Kumar" class="founder-img img-fluid rounded-circle" />
             <p>
               Over the past 8+ years, I’ve worked with some of the world’s
               largest financial institutions, including J.P. Morgan, BNY

--- a/style.css
+++ b/style.css
@@ -19,20 +19,20 @@ body {
   color: #fff;
 }
 
-.hero .image img {
+.hero img {
   max-width: 100%;
   max-height: 400px;
   object-fit: cover;
 }
 
 @media (max-width: 768px) {
-  .hero .image img {
+  .hero img {
     max-height: 300px;
   }
 }
 
 @media (max-width: 576px) {
-  .hero .image img {
+  .hero img {
     max-height: 250px;
   }
 }
@@ -41,5 +41,4 @@ body {
   max-width: 200px;
   width: 100%;
   height: auto;
-  border-radius: 50%;
 }


### PR DESCRIPTION
## Summary
- load Bootstrap and Bootswatch Lux from CDN and keep custom overrides separate
- refactor hero, promo and founder sections with Bootstrap layout classes
- prune custom CSS to only minimal overrides

## Testing
- `npx --yes playwright@1.55.0 screenshot -b chromium --viewport-size=390,844 file://$(pwd)/index.html mobile.png`

------
https://chatgpt.com/codex/tasks/task_e_68c4f70e77dc832bb6561be5002f3b70