### PR TITLE
Limit hero image height for mobile comfort

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
               ></i>
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-6 image">
             <picture>
               <source
                 srcset="https://images.unsplash.com/photo-1556155092-8707de31f9c4?auto=format&fit=crop&w=1980&q=80"

--- a/style.css
+++ b/style.css
@@ -25,12 +25,6 @@ body {
   object-fit: cover;
 }
 
-@media (max-width: 768px) {
-  .hero .image img {
-    max-height: 300px;
-  }
-}
-
 @media (max-width: 576px) {
   .hero .image img {
     max-height: 250px;


### PR DESCRIPTION
## Summary
- constrain hero image height and maintain aspect ratio
- ensure small screens cap hero image at 250px
- mark hero image container so styling applies

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx playwright screenshot --device="Pixel 5" file:index.html hero-mobile.png` *(fails: Playwright browser not installed; download returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fb07bad0832b91ff18868462d433