### PR TITLE
feat: use high-res external social image

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Jobaance - Learn Finance. Gain Skills. Get Job-Ready.</title>
     <meta
       property="og:image"
-      content="https://raw.githubusercontent.com/github/explore/main/topics/javascript/javascript.png"
+      content="https://raw.githubusercontent.com/vercel/next.js/canary/examples/with-mux-video/app/opengraph-image.png"
     />
     <meta
       property="og:type"
@@ -14,7 +14,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://raw.githubusercontent.com/github/explore/main/topics/javascript/javascript.png"
+      content="https://raw.githubusercontent.com/vercel/next.js/canary/examples/with-mux-video/app/opengraph-image.png"
     />
     <meta
       name="twitter:url"


### PR DESCRIPTION
## Summary
- use high-resolution external image for social previews
- repository already clean of `images/preview.png`

## Testing
- `curl -I https://raw.githubusercontent.com/vercel/next.js/canary/examples/with-mux-video/app/opengraph-image.png`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c508b5f148832b9f00218a8b0695e1