### PR TITLE
chore: use external social preview image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+images/preview.png

--- a/index.html
+++ b/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Jobaance - Learn Finance. Gain Skills. Get Job-Ready.</title>
-    <meta
-      property="og:image"
-      content="https://raw.githubusercontent.com/vercel/next.js/canary/examples/with-mux-video/app/opengraph-image.png"
-    />
+      <meta
+        property="og:image"
+        content="https://raw.githubusercontent.com/github/explore/main/topics/python/python.png"
+      />
     <meta
       property="og:type"
       content="website"
     />
-    <meta
-      name="twitter:image"
-      content="https://raw.githubusercontent.com/vercel/next.js/canary/examples/with-mux-video/app/opengraph-image.png"
-    />
+      <meta
+        name="twitter:image"
+        content="https://raw.githubusercontent.com/github/explore/main/topics/python/python.png"
+      />
     <meta
       name="twitter:url"
       content="https://jobaance.com/"


### PR DESCRIPTION
## Summary
- stop tracking `images/preview.png`
- point social preview meta tags to externally hosted image

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Jobaance/package.json')*
- `curl -I https://raw.githubusercontent.com/github/explore/main/topics/python/python.png`


------
https://chatgpt.com/codex/tasks/task_e_68c512cc9910832b99c039026f66971b