### PR TITLE
Replace pricing promo with WhatsApp CTA and refine founder image

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,9 +191,15 @@
           <li class="col">Tools: Excel, SQL, Power BI, Bloomberg Basics</li>
           <li class="col">Resume Building & Interview Prep</li>
         </ul>
-        <div class="mt-3 fw-bold text-danger">
-          <p>👉 First Class at Just ₹49</p>
-          <p>👉 Full Program ₹4,999 (Revealed after trial)</p>
+        <div class="mt-4">
+          <a
+            href="https://wa.me/919168760311"
+            class="btn btn-success"
+            target="_blank"
+            rel="noopener"
+          >
+            <i class="fab fa-whatsapp"></i> WhatsApp for Course Details
+          </a>
         </div>
       </div>
     </section>
@@ -315,12 +321,20 @@
         <h2 class="section-title text-center">Founders’ Message</h2>
         <div class="row justify-content-center align-items-center">
           <div class="col-md-4 text-center mb-4 mb-md-0">
-            <img src="https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg" alt="Prashant Kumar" class="img-fluid rounded-circle" />
+            <img
+              src="https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg"
+              alt="Prashant Kumar"
+              class="founder-img img-fluid rounded-circle"
+            />
           </div>
           <div class="col-lg-8">
             <h3>Prashant Kumar – Co-Founder & Lead Trainer</h3>
-            <img src="https://jobaance-mayxs.s3.amazonaws.com/images/prashant_1.jpg" alt="Prashant Kumar" class="founder-img" />
-            <a href="https://www.linkedin.com/in/prashant-kumar-9970bbb6/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+            <a
+              href="https://www.linkedin.com/in/prashant-kumar-9970bbb6/"
+              target="_blank"
+              rel="noopener"
+              ><i class="fab fa-linkedin"></i
+            ></a>
             <p>
               Over the past 8+ years, I’ve worked with some of the world’s
               largest financial institutions, including J.P. Morgan, BNY

--- a/style.css
+++ b/style.css
@@ -50,8 +50,11 @@ body {
 }
 
 .founder-img {
-  max-width: 200px;
+  width: 100%;
+  max-width: 250px;
+  height: auto;
   border-radius: 50%;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
 }
 
 /* Instagram icon link styling */


### PR DESCRIPTION
## Summary
- Replace trial pricing details with a WhatsApp button for course inquiries
- Make founder image responsive with rounded styling and subtle shadow
- Polish styles to give the site a more premium feel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c656d99838832b9c4b25dacfe0a1ad