### PR TITLE
Add 30-day program overview section

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,22 @@
       </div>
     </section>
 
+    <section id="program" class="py-5" data-aos="fade-up">
+      <div class="container">
+        <h2 class="section-title text-center">30-Day Complete Job-Ready Program</h2>
+        <p class="lead text-center">A power-packed training delivering practical finance knowledge and hands-on tools in just 30 days.</p>
+        <ul class="row row-cols-1 row-cols-md-2 g-2 list-unstyled">
+          <li class="col">Investment Banking Operations – Trade Life Cycle, Settlements, Reconciliation</li>
+          <li class="col">Fund Accounting &amp; NAV Calculations</li>
+          <li class="col">Capital Markets &amp; Asset Servicing</li>
+          <li class="col">Risk &amp; Compliance Basics</li>
+          <li class="col">Software Tools for Finance – Excel, SQL, Power BI, Bloomberg (basics)</li>
+          <li class="col">Career Support – Resume Building, Mock Interviews, Job Guidance</li>
+        </ul>
+        <p class="mt-3">Outcome: Gain confidence, industry-ready skills, and job opportunities in Investment Banking, Fund Accounting, Middle Office, and Asset Management.</p>
+      </div>
+    </section>
+
     <section id="who" class="py-5" data-aos="fade-up">
       <div class="container">
         <h2 class="section-title text-center">Who Can Join</h2>

--- a/style.css
+++ b/style.css
@@ -84,6 +84,18 @@ body {
   color: #fff;
 }
 
+#program ul li {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+#program ul li::before {
+  content: "•";
+  color: #2575fc;
+  position: absolute;
+  left: 0;
+}
+
 #who p.lead {
   font-weight: 400;
   margin-bottom: 1.5rem;


### PR DESCRIPTION
## Summary
- Introduce new "30-Day Complete Job-Ready Program" section detailing curriculum and outcomes.
- Style program list with custom bullets for a clean, responsive layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c667ab0fa0832ba6d0435b10f3c20d